### PR TITLE
fix: throw proper errors when converting device object

### DIFF
--- a/src/TestIOUtil.ts
+++ b/src/TestIOUtil.ts
@@ -74,9 +74,24 @@ export class TestIOUtil {
 
     static async getDevicePayloadFromPrepareObjectDeviceSpec(device: { category: string; os: string; min: string; max?: string; } ): Promise<any> {
         const categoryId = await TestIOUtil.retrieveDeviceCategoryIdByName(device.category);
+        if (categoryId == -1) {
+            throw new Error(`Category '${device.category}' is not valid`);
+        }
+
         const osId = await TestIOUtil.retrieveOperatingSystemIdByDeviceCategoryIdAndName(categoryId, device.os);
+        if (osId == -1) {
+            throw new Error(`OS name '${device.os}' is not valid`);
+        }
+
         const minVersionId = await TestIOUtil.retrieveOsVersionIdByOsIdAndVersion(osId, device.min);
+        if (minVersionId == -1) {
+            throw new Error(`Min version '${device.min}' is not valid`);
+        }
+
         const maxVersionId = (device.max ? await TestIOUtil.retrieveOsVersionIdByOsIdAndVersion(osId, device.max) : null);
+        if (maxVersionId == -1) {
+            throw new Error(`Max version '${device.max}' is not valid`);
+        }
 
         return {
             requirements: [

--- a/src/retrievePayload.ts
+++ b/src/retrievePayload.ts
@@ -45,7 +45,7 @@ async function createPayload() {
 
     const prepareObject = gha.retrieveValidPrepareObjectFromComment(commentContents);
     const prTitle: string = await gha.retrievePrTitle();
-    gha.createAndPersistTestIoPayload(prepareObject, prTitle);
+    await gha.createAndPersistTestIoPayload(prepareObject, prTitle);
 }
 
 createPayload().then();

--- a/test/TestIOUtil.test.ts
+++ b/test/TestIOUtil.test.ts
@@ -181,6 +181,52 @@ describe("TestIO Device API Util", () => {
         expect(devicePayload).toEqual(expectedDevicePayload);
     });
 
+    it('should validate the device spec correctly', async () => {
+        let device: { min: string; os: string; max?: string; category: string } = {
+            os: "wrongOS",
+            category: "smartphone",
+            min: "8.0"
+        };
+        await expect(async () => await TestIOUtil.getDevicePayloadFromPrepareObjectDeviceSpec(device)).rejects.toThrowError("OS name 'wrongOS' is not valid");
+
+        device = {
+            os: "ios",
+            category: "wrongCategory",
+            min: "8.0"
+        };
+        await expect(async () => await TestIOUtil.getDevicePayloadFromPrepareObjectDeviceSpec(device)).rejects.toThrowError("Category 'wrongCategory' is not valid");
+
+        device = {
+            os: "android",
+            category: "smartphone",
+            min: "8.invalid.0"
+        };
+        await expect(async () => await TestIOUtil.getDevicePayloadFromPrepareObjectDeviceSpec(device)).rejects.toThrowError("Min version '8.invalid.0' is not valid");
+
+        device = {
+            os: "android",
+            category: "smartphone",
+            min: "8.0"
+        };
+        await expect(async () => await TestIOUtil.getDevicePayloadFromPrepareObjectDeviceSpec(device)).resolves;
+
+        device = {
+            os: "android",
+            category: "smartphone",
+            min: "8.0",
+            max: "13.0.invalid"
+        };
+        await expect(async () => await TestIOUtil.getDevicePayloadFromPrepareObjectDeviceSpec(device)).rejects.toThrowError("Max version '13.0.invalid' is not valid");
+
+        device = {
+            os: "android",
+            category: "smartphone",
+            min: "8.0",
+            max: "13.0"
+        };
+        await expect(async () => await TestIOUtil.getDevicePayloadFromPrepareObjectDeviceSpec(device)).resolves;
+    });
+
     it('should translate device spec without max version into TestIO device payload', async () => {
         const osName = "ios";
         const categoryName = "smartphone";


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

The user needs a proper error message when invalid information for the devices are provided in the prepare comment. 

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
