### PR TITLE
fix: wrong prepare comment when default creation trigger used

### DIFF
--- a/src/TestIOTriggerTestGHA.ts
+++ b/src/TestIOTriggerTestGHA.ts
@@ -24,7 +24,7 @@ import {TestIOUtil} from "./TestIOUtil";
 
 export class TestIOTriggerTestGHA {
 
-    public static readonly CREATE_COMMENT_PREFIX = "@bot-testio exploratory-test create ";
+    public static readonly CREATE_COMMENT_PREFIX = "@bot-testio exploratory-test create";
 
     public static readonly persistedPayloadFile = 'temp/testio_payload.json';
     private static readonly commentPrepareTemplateFile = "exploratory_test_comment_prepare_template.md";


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

As can be seen in [this prepare comment](https://github.com/Staffbase/testio-management/pull/107#issuecomment-1801290072) the device spec is added even the default create comment (without `android` or `ios`) was used [here](https://github.com/Staffbase/testio-management/pull/107#issuecomment-1801289241). The wrong part of the prepare comment is the following:

```json
"device": {
    "os": "@bot-testio",
    "category": "exploratory-test",
    "min": "8.0",
    "max": "10"
  }
```
This shouldn't be there for the default create comment. More precisely, `os` and `category` are completely wrong.

The root cause of the bug is that the `CREATE_COMMENT_PREFIX` we use in the implementation to split up the creation comment contained a trailing space. Thus, wrong data was extracted. This fix removes the trailing space.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
