### PR TITLE
✨ early error message when wrong os or device category

### DIFF
--- a/src/TestIOTriggerTestGHA.ts
+++ b/src/TestIOTriggerTestGHA.ts
@@ -121,6 +121,21 @@ export class TestIOTriggerTestGHA {
             const deviceSpecParts = commentSuffix.split(/\s+/);
             const osName = deviceSpecParts[0];
             const categoryName = (deviceSpecParts[1] ? deviceSpecParts[1] : "smartphones");
+
+            const deviceCategoryId = await TestIOUtil.retrieveDeviceCategoryIdByName(categoryName);
+            if (deviceCategoryId == -1) {
+                const errorMessage = `Device category '${categoryName}' is not valid`;
+                const error = Util.prepareErrorMessageAndOptionallyThrow(errorMessage, this.errorFile, true);
+                return Promise.reject(error);
+            }
+
+            const osId = await TestIOUtil.retrieveOperatingSystemIdByDeviceCategoryIdAndName(deviceCategoryId, osName);
+            if (osId == -1) {
+                const errorMessage = `Operating System '${osName}' is not valid`;
+                const error = Util.prepareErrorMessageAndOptionallyThrow(errorMessage, this.errorFile, true);
+                return Promise.reject(error);
+            }
+
             device = {
                     os: osName,
                     category: categoryName,

--- a/test/TestIOTriggerTestGHA.test.ts
+++ b/test/TestIOTriggerTestGHA.test.ts
@@ -145,6 +145,29 @@ describe("Trigger TestIO Test GHA", () => {
         await expect(gha.triggerTestIoTest()).rejects.toEqual(new Error("TestIO properties are not configured"));
     });
 
+    it('should return Error with wrong create comment attributes', async () => {
+        let gha = setupWithMockedCommentCreation();
+        const createCommentUrl = `https://github.com/${owner}/${repo}/issues/${pr}/comments#987654321`;
+
+        // os: wrong, device category: correct
+        let createComment = "@bot-testio exploratory-test create androiddd"; // without category it defaults to 'smartphones'
+        await expect(gha.addPrepareComment(createCommentUrl, createComment)).rejects.toEqual(new Error("Operating System 'androiddd' is not valid"));
+        createComment = "@bot-testio exploratory-test create iossss tablets";
+        await expect(gha.addPrepareComment(createCommentUrl, createComment)).rejects.toEqual(new Error("Operating System 'iossss' is not valid"));
+
+        // os: wrong, device category: wrong
+        createComment = "@bot-testio exploratory-test create androiddd tabletssss";
+        await expect(gha.addPrepareComment(createCommentUrl, createComment)).rejects.toEqual(new Error("Device category 'tabletssss' is not valid"));
+
+        // os: correct, device category: wrong
+        createComment = "@bot-testio exploratory-test create android tabletsXYZ";
+        await expect(gha.addPrepareComment(createCommentUrl, createComment)).rejects.toEqual(new Error("Device category 'tabletsXYZ' is not valid"));
+
+        // os: correct, device category: correct
+        createComment = "@bot-testio exploratory-test create ios smartphones";
+        await expect(gha.addPrepareComment(createCommentUrl, createComment)).resolves.toBeDefined();
+    });
+
     describe("[default context] Comment Creation and Retrieval", () => {
 
         it("should create comment", async () => {


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

If the create comment contains wrong attributes (such as wrong os or wrong device category) we now get an early error message as the results. Before, the prepare comment was added anyway and the validity was checked later, when the user already put effort in it to specify the prepare comment.  

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
